### PR TITLE
fix(.demo-component-code-container): add explicit 100% width

### DIFF
--- a/_component.demo.scss
+++ b/_component.demo.scss
@@ -66,6 +66,10 @@
   width: 100%;
 }
 
+.demo-component-code-container {
+  width: 100%;
+}
+
 .demo-component-container{
   min-height: calculateRem(400px);
   background: var(--px-demo-component-background-color, $white);


### PR DESCRIPTION
This is the fix for https://github.com/vaadin/px-data-grid/issues/180

To be honest, I don't understand why the explicit `width: 100%` is needed for IE11, but it works.

For other browsers, this change doesn't have any effect.